### PR TITLE
revert to manual trivy setup; can't get the GHA to behave

### DIFF
--- a/.github/trivy-config.yaml
+++ b/.github/trivy-config.yaml
@@ -1,7 +1,6 @@
 license:
     confidencelevel: "0.9"
-    forbidden: # TODO: confirm list of forbidden licenses
-        - AGPL-1.0
+    forbidden: # the list of licenses we want to block in the scan results
         - AGPL-3.0
-        - GPL-2.0
-        - LGPL
+        - GPL-3.0
+        - CC-BY-SA # included as a sanity check. Not a type of license we would want to block otherwise.

--- a/.github/workflows/trivy-license.yaml
+++ b/.github/workflows/trivy-license.yaml
@@ -1,8 +1,6 @@
-name: Trivy License
-
+name: Trivy License Scanning
 on:
   workflow_dispatch:
-
 jobs:
   trivy-license:
     name: Trivy License Scan
@@ -14,9 +12,8 @@ jobs:
       matrix:
         repository:
           - owner: grafana
-            repo: grafana # this has go.mod and package.json in the root
+            repo: grafana 
             ref: main
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,12 +51,12 @@ jobs:
       - name: Trivy Scan
         run: |
           trivy fs --scanners license  --format json --exit-code 0 --output trivy-license-scan-results.json ./target
-      - name: Parse Custom License Definition
+      - name: Parse Custom License Definition # uses yq to parse the list of forbidden licenses in the trivy-config.yaml file
         id: parse_custom_license_definition
         uses: mikefarah/yq@f03c9dc599c37bfcaf533427211d05e51e6fee64
         with:
           cmd: yq '.license.forbidden[]' ./.github/trivy-config.yaml
-      - name: Show only Forbidden Licenses
+      - name: Show only Forbidden Licenses # filter the results down to only forbidden licenses
         run: |
           forbidden_licenses="${{ steps.parse_custom_license_definition.outputs.result }}"
           > forbidden-licenses-found.json
@@ -67,7 +64,7 @@ jobs:
             jq --arg lic "$license" '{Results: [.Results[].Licenses[]? | select(.Name == $lic)]}' trivy-license-scan-results.json >> forbidden-licenses-found.json
           done
           cat forbidden-licenses-found.json
-      - name: Filter Out Grafana Repo Results
+      - name: Filter Out Grafana Repo Results # it is ok to use the org's own repos, regardless of their license
         run: |
           jq '{Results: [.Results[] | select(.PkgName | startswith("github.com/grafana/") | not)]}' forbidden-licenses-found.json > filtered-licenses.json
           cat filtered-licenses.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # shared-security-workflows
 
-Simulates a central repository for implementing security workflows. See examples in the .github/workflows directory
+The idea with this repository is to simulate a central repository of workflows that are shared across an entire Github org. An organization might create a number of security workflows that are shared across all repositories in this way.  
+
+## Trivy License Scanning
+
+The Trivy license scan workflow is implemented in `.github/workflows/trivy-license.yaml`, with an accompanying config file, `workflows/trivy-config.yaml.` Licenses added to the forbidden section of the config file will cause the workflow to exit non-zero if any of the licenses are present in the target repo being scanned.
+
+The idea is to implement the license scanning as a shared workflow that is called across all repos in the org when a pull request is created in each repo. If a forbidden license is being introduced by the change in the pull request, then the license scan will fail, hence blocking the pull request.
+
+The current implementation uses a static target repo, grafana/grafana, and is triggered by a `workflow_dispatch` trigger.


### PR DESCRIPTION
uses the manual trivy set-up and yq to implement scanner license definition.